### PR TITLE
Add photo and schedule endpoints with i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Reiseplaner API
 
-This project exposes a small HTTP server implemented in `server.js`. The API covers points of interest, weather data, directions and activity suggestions. The full schema for all endpoints can be found in [openapi.json](openapi.json).
+This project exposes a small HTTP server implemented in `server.js`. The API covers points of interest, weather data, directions and activity suggestions. Additional helper endpoints provide photos and day plans. The full schema for all endpoints can be found in [openapi.json](openapi.json).
+
+Key additions:
+- `/foto` – returns a CDN image URL for a Google Places `photo_reference`.
+- `/tagesablauf` – produces a simple timetable for the day.
+- `/vorschlag` – suggestions now include audience tags (`familie`, `paar`, `adrenalin`).
 
 ## Requirements
 

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -1,0 +1,7 @@
+{
+  "ort": "Ort",
+  "zeitbudget": "Zeitbudget",
+  "wetter": "Wetter",
+  "empfehlung": "Basierend auf Wetter und Interessen empfehlen wir dir:",
+  "server_live": "Server live. Nutze /orte, /wetter oder /vorschlag?ort=currentlocation&zeit=3&interessen=wandern,museum"
+}

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,0 +1,7 @@
+{
+  "ort": "Location",
+  "zeitbudget": "Time budget",
+  "wetter": "Weather",
+  "empfehlung": "Based on weather and interests we suggest:",
+  "server_live": "Server live. Use /orte, /wetter or /vorschlag?ort=currentlocation&zeit=3&interessen=wandern,museum"
+}

--- a/openapi.json
+++ b/openapi.json
@@ -10,7 +10,9 @@
     }
   },
   "servers": [
-    { "url": "https://reiseplaner.onrender.com" }
+    {
+      "url": "https://reiseplaner.onrender.com"
+    }
   ],
   "paths": {
     "/vorschlag": {
@@ -21,28 +23,38 @@
           {
             "name": "ort",
             "in": "query",
-            "schema": { "type": "string", "default": "Bern" },
+            "schema": {
+              "type": "string",
+              "default": "Bern"
+            },
             "required": false,
             "description": "Stadtname"
           },
           {
             "name": "zeit",
             "in": "query",
-            "schema": { "type": "integer", "default": 2 },
+            "schema": {
+              "type": "integer",
+              "default": 2
+            },
             "required": false,
             "description": "Zeitbudget in Stunden"
           },
           {
             "name": "interessen",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": false,
             "description": "Kommagetrennte Interessen"
           },
           {
             "name": "format",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": false,
             "description": "\"json\" für strukturiertes Ergebnis"
           }
@@ -56,7 +68,22 @@
                   "ort": "Bern",
                   "zeit": 2,
                   "wetter": "klar",
-                  "vorschlaege": ["museum", "kino"]
+                  "vorschlaege": [
+                    {
+                      "name": "museum",
+                      "tags": [
+                        "familie",
+                        "paar"
+                      ]
+                    },
+                    {
+                      "name": "kino",
+                      "tags": [
+                        "familie",
+                        "paar"
+                      ]
+                    }
+                  ]
                 }
               },
               "text/plain": {
@@ -75,21 +102,29 @@
           {
             "name": "ort",
             "in": "query",
-            "schema": { "type": "string", "default": "Bern" },
+            "schema": {
+              "type": "string",
+              "default": "Bern"
+            },
             "required": false,
             "description": "Stadtname"
           },
           {
             "name": "typ",
             "in": "query",
-            "schema": { "type": "string", "default": "museum" },
+            "schema": {
+              "type": "string",
+              "default": "museum"
+            },
             "required": false,
             "description": "Ortstyp"
           },
           {
             "name": "maxDist",
             "in": "query",
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "required": false,
             "description": "Maximale Entfernung in Metern"
           }
@@ -97,7 +132,9 @@
         "responses": {
           "200": {
             "description": "Antwort von Google Places",
-            "content": { "application/json": {} }
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }
@@ -110,7 +147,9 @@
           {
             "name": "adresse",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": false,
             "description": "Adresse"
           }
@@ -118,7 +157,9 @@
         "responses": {
           "200": {
             "description": "Geocodergebnis",
-            "content": { "application/json": {} }
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }
@@ -131,21 +172,28 @@
           {
             "name": "lat",
             "in": "query",
-            "schema": { "type": "number" },
+            "schema": {
+              "type": "number"
+            },
             "required": true,
             "description": "Breitengrad"
           },
           {
             "name": "lng",
             "in": "query",
-            "schema": { "type": "number" },
+            "schema": {
+              "type": "number"
+            },
             "required": true,
             "description": "Längengrad"
           },
           {
             "name": "typ",
             "in": "query",
-            "schema": { "type": "string", "default": "tourist_attraction" },
+            "schema": {
+              "type": "string",
+              "default": "tourist_attraction"
+            },
             "required": false,
             "description": "Ortstyp"
           }
@@ -153,7 +201,9 @@
         "responses": {
           "200": {
             "description": "Antwort von Google Places",
-            "content": { "application/json": {} }
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }
@@ -166,21 +216,28 @@
           {
             "name": "start",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": true,
             "description": "Startort"
           },
           {
             "name": "ziel",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": true,
             "description": "Zielort"
           },
           {
             "name": "modus",
             "in": "query",
-            "schema": { "type": "string", "default": "driving" },
+            "schema": {
+              "type": "string",
+              "default": "driving"
+            },
             "required": false,
             "description": "Fortbewegungsmodus"
           }
@@ -191,8 +248,16 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "identisch": { "value": { "message": "Start und Ziel identisch" } },
-                  "google": { "value": { "routes": [] } }
+                  "identisch": {
+                    "value": {
+                      "message": "Start und Ziel identisch"
+                    }
+                  },
+                  "google": {
+                    "value": {
+                      "routes": []
+                    }
+                  }
                 }
               }
             }
@@ -202,7 +267,11 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "missing": { "value": { "error": "Start oder Ziel fehlt" } }
+                  "missing": {
+                    "value": {
+                      "error": "Start oder Ziel fehlt"
+                    }
+                  }
                 }
               }
             }
@@ -218,14 +287,18 @@
           {
             "name": "userOrt",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": true,
             "description": "Startort"
           },
           {
             "name": "zielOrt",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "required": true,
             "description": "Zielort"
           }
@@ -236,8 +309,17 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "identisch": { "value": { "message": "Start und Ziel identisch" } },
-                  "zeit": { "value": { "dauer": "10 min", "abfahrt": "12:00" } }
+                  "identisch": {
+                    "value": {
+                      "message": "Start und Ziel identisch"
+                    }
+                  },
+                  "zeit": {
+                    "value": {
+                      "dauer": "10 min",
+                      "abfahrt": "12:00"
+                    }
+                  }
                 }
               }
             }
@@ -247,7 +329,11 @@
             "content": {
               "application/json": {
                 "examples": {
-                  "missing": { "value": { "error": "Start oder Ziel fehlt" } }
+                  "missing": {
+                    "value": {
+                      "error": "Start oder Ziel fehlt"
+                    }
+                  }
                 }
               }
             }
@@ -263,7 +349,10 @@
           {
             "name": "ort",
             "in": "query",
-            "schema": { "type": "string", "default": "Bern" },
+            "schema": {
+              "type": "string",
+              "default": "Bern"
+            },
             "required": false,
             "description": "Stadtname"
           }
@@ -271,7 +360,83 @@
         "responses": {
           "200": {
             "description": "Wetterdaten",
-            "content": { "application/json": {} }
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/foto": {
+      "get": {
+        "operationId": "fotoUrl",
+        "summary": "Gibt eine Google-Photo-URL zurück",
+        "parameters": [
+          {
+            "name": "reference",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "photo_reference aus Places API"
+          },
+          {
+            "name": "maxwidth",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 400
+            },
+            "required": false,
+            "description": "Breite des Bildes"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "URL",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "400": {
+            "description": "Fehlende reference"
+          }
+        }
+      }
+    },
+    "/tagesablauf": {
+      "get": {
+        "operationId": "tagesablaufGenerieren",
+        "summary": "Erzeugt einen einfachen Tagesplan",
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "09:00"
+            },
+            "required": false,
+            "description": "Startzeit HH:mm"
+          },
+          {
+            "name": "tz",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "Europe/Berlin"
+            },
+            "required": false,
+            "description": "Zeitzone"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Plan",
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,5 +7,9 @@
   },
   "engines": {
     "node": ">=16"
+  },
+  "dependencies": {
+    "i18next": "^22.4.9",
+    "moment-timezone": "^0.5.40"
   }
 }

--- a/server.js
+++ b/server.js
@@ -2,6 +2,10 @@
 const http = require('http');
 const https = require('https');
 const url = require('url');
+const fs = require('fs');
+const path = require('path');
+const moment = require('moment-timezone');
+const i18next = require('i18next');
 
 const hostname = '0.0.0.0';
 const port = process.env.PORT || 3000;
@@ -19,6 +23,14 @@ if (missingKeys.length) {
   );
 }
 
+i18next.init({
+  fallbackLng: 'en',
+  resources: {
+    en: { translation: JSON.parse(fs.readFileSync(path.join(__dirname, 'locales/en/translation.json'), 'utf8')) },
+    de: { translation: JSON.parse(fs.readFileSync(path.join(__dirname, 'locales/de/translation.json'), 'utf8')) }
+  }
+});
+
 function haversineDistance(lat1, lon1, lat2, lon2) {
   const R = 6371000; // meters
   const toRad = deg => (deg * Math.PI) / 180;
@@ -31,6 +43,19 @@ function haversineDistance(lat1, lon1, lat2, lon2) {
   return R * c;
 }
 
+const activityTags = {
+  'wandern': ['familie', 'adrenalin'],
+  'spaziergang': ['familie'],
+  'see': ['familie', 'paar'],
+  'stadtbummel': ['familie', 'paar'],
+  'biergarten': ['paar'],
+  'museum': ['familie', 'paar'],
+  'wellness': ['paar'],
+  'kino': ['familie', 'paar'],
+  'escape room': ['familie', 'adrenalin'],
+  'kaffeehaus': ['paar']
+};
+
 const server = http.createServer((req, res) => {
   if (missingKeys.length) {
     res.statusCode = 500;
@@ -42,6 +67,8 @@ const server = http.createServer((req, res) => {
   }
   const parsedUrl = url.parse(req.url, true);
   const query = parsedUrl.query;
+  const lang = (req.headers['accept-language'] || 'en').split(',')[0].split('-')[0];
+  i18next.changeLanguage(lang);
 
   // --- Vorschlagslogik ---
   if (parsedUrl.pathname === '/vorschlag') {
@@ -76,7 +103,9 @@ const server = http.createServer((req, res) => {
           vorschlaege = kandidaten.slice(0, 3);
         }
 
-        const antwortText = `📍 Ort: ${ort}\n🕒 Zeitbudget: ${zeit}h\n🌤️ Wetter: ${wetterBeschreibung || 'unbekannt'}\n\n✨ Basierend auf Wetter und Interessen empfehlen wir dir:\n• ` + vorschlaege.join('\n• ');
+        const items = vorschlaege.map(v => ({ name: v, tags: activityTags[v] || [] }));
+
+        const antwortText = `📍 ${i18next.t('ort')}: ${ort}\n🕒 ${i18next.t('zeitbudget')}: ${zeit}h\n🌤️ ${i18next.t('wetter')}: ${wetterBeschreibung || 'unbekannt'}\n\n✨ ${i18next.t('empfehlung')}\n• ` + vorschlaege.join('\n• ');
 
         if (query.format === "json") {
           res.setHeader('Content-Type', 'application/json');
@@ -84,7 +113,7 @@ const server = http.createServer((req, res) => {
             ort,
             zeit,
             wetter: wetterBeschreibung,
-            vorschlaege
+            vorschlaege: items
           }));
         } else {
           res.setHeader('Content-Type', 'text/plain');
@@ -181,6 +210,22 @@ const server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'application/json');
       res.end(JSON.stringify({ error: err.message }));
     });
+    return;
+  }
+
+  // --- /foto-Route ---
+  if (parsedUrl.pathname === '/foto') {
+    const reference = query.reference || '';
+    const maxwidth = query.maxwidth || 400;
+    if (!reference) {
+      res.statusCode = 400;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'reference fehlt' }));
+      return;
+    }
+    const urlPhoto = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=${maxwidth}&photoreference=${encodeURIComponent(reference)}&key=${GOOGLE_API_KEY}`;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ url: urlPhoto }));
     return;
   }
 
@@ -285,6 +330,24 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  // --- /tagesablauf-Route ---
+  if (parsedUrl.pathname === '/tagesablauf') {
+    const start = query.start || '09:00';
+    const tz = query.tz || 'Europe/Berlin';
+    const dauerAkt = parseInt(query.dauerAktivitaet) || 60;
+
+    const startMoment = moment.tz(start, 'HH:mm', tz);
+    const plan = [
+      { step: 'Anreise', time: startMoment.format('HH:mm') },
+      { step: 'Aktivit\u00e4t', time: startMoment.clone().add(30, 'minutes').format('HH:mm') },
+      { step: 'Essen', time: startMoment.clone().add(30 + dauerAkt, 'minutes').format('HH:mm') },
+      { step: 'R\u00fcckreise', time: startMoment.clone().add(90 + dauerAkt, 'minutes').format('HH:mm') }
+    ];
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ plan }));
+    return;
+  }
+
   // --- /wetter-Route ---
   if (parsedUrl.pathname === '/wetter') {
     const ort = query.ort || 'Bern';
@@ -308,7 +371,7 @@ const server = http.createServer((req, res) => {
   // --- Standard-Antwort ---
   res.statusCode = 200;
   res.setHeader('Content-Type', 'text/plain');
-  res.end('Server live. Nutze /orte, /wetter oder /vorschlag?ort=currentlocations&zeit=3&interessen=wandern,museum');
+  res.end(i18next.t('server_live'));
 });
 
 server.listen(port, hostname, () => {


### PR DESCRIPTION
## Summary
- introduce i18next and moment-timezone
- add activity tags and localized responses
- new `/foto` endpoint to build Google Places photo URLs
- new `/tagesablauf` endpoint for simple daily plans
- document new features and extend OpenAPI schema

## Testing
- `node -c server.js`

------
https://chatgpt.com/codex/tasks/task_e_686fdafb36a08327a6d23ca8bfcfc6aa