### PR TITLE
Update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ export OPENWEATHER_API_KEY=yourOpenWeatherKey
 export PORT=8080   # optional
 ```
 
-Install dependencies and start the server with **npm**:
+Install the required dependencies first:
 
 ```bash
 npm install
+```
+
+Then start the server:
+
+```bash
 npm start
 ```


### PR DESCRIPTION
## Summary
- refine running instructions for setting up the server

## Testing
- `npm start` *(fails: Cannot find module 'i18next')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687024216b008327ba77aca4f1db4d8c