### PR TITLE
Add transit support to route endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Key additions:
 - `/foto` – resolves a Places `photo_reference` to the final CDN URL.
 - `/tagesablauf` – produces a simple timetable for the day.
 - `/vorschlag` – suggestions include audience tags (`familie`, `paar`, `adrenalin`) and now validate input using **zod**.
+- `/route` – supports public transit via `modus=transit` and optional `abfahrt`.
 
 ## Requirements
 

--- a/openapi.json
+++ b/openapi.json
@@ -221,8 +221,17 @@
             "schema": {
               "type": "string"
             },
-            "required": true,
+            "required": false,
             "description": "Startort"
+          },
+          {
+            "name": "von",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Alias f\u00fcr start"
           },
           {
             "name": "ziel",
@@ -230,8 +239,17 @@
             "schema": {
               "type": "string"
             },
-            "required": true,
+            "required": false,
             "description": "Zielort"
+          },
+          {
+            "name": "nach",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Alias f\u00fcr ziel"
           },
           {
             "name": "modus",
@@ -242,6 +260,15 @@
             },
             "required": false,
             "description": "Fortbewegungsmodus"
+          },
+          {
+            "name": "abfahrt",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Unixzeitpunkt oder 'now' f\u00fcr Transit"
           }
         ],
         "responses": {

--- a/server.js
+++ b/server.js
@@ -316,8 +316,8 @@ const server = http.createServer((req, res) => {
 
   // --- /route-Route ---
   if (parsedUrl.pathname === '/route') {
-    const origin = (query.start || '').trim();
-    const destination = (query.ziel || '').trim();
+    const origin = (query.start || query.von || '').trim();
+    const destination = (query.ziel || query.nach || '').trim();
     const mode = query.modus || 'driving';
 
     if (!origin || !destination) {
@@ -333,7 +333,12 @@ const server = http.createServer((req, res) => {
       return;
     }
 
-    const endpoint = `https://maps.googleapis.com/maps/api/directions/json?origin=${encodeURIComponent(origin)}&destination=${encodeURIComponent(destination)}&mode=${encodeURIComponent(mode)}&key=${GOOGLE_API_KEY}`;
+    let extra = '';
+    if (mode === 'transit') {
+      const when = query.abfahrt ? encodeURIComponent(query.abfahrt) : 'now';
+      extra = `&departure_time=${when}`;
+    }
+    const endpoint = `https://maps.googleapis.com/maps/api/directions/json?origin=${encodeURIComponent(origin)}&destination=${encodeURIComponent(destination)}&mode=${encodeURIComponent(mode)}${extra}&key=${GOOGLE_API_KEY}`;
 
     https.get(endpoint, apiRes => {
       let data = '';


### PR DESCRIPTION
## Summary
- allow `/route` to accept `von` and `nach` as aliases
- support transit departure time via `abfahrt`
- document new parameters in the OpenAPI schema
- mention transit usage in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: Cannot find module 'i18next')*

------
https://chatgpt.com/codex/tasks/task_e_6870a12a96d883279be0e303cac32496